### PR TITLE
Add Fuzzy matching option and alias string stripping

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,11 @@ Helpful functions for analyzing an export of OpsGenie alerts and collecting usef
         * A filter matching alerts that update within x minutes (between "CreatedAt" and "UpdatedAt" timestamps)
     * Output file **(--outfile _filename_)**
         * A file to output the results of --count
+    * Fuzzy Threshold **(--fuzzy-threshold _threshold_)**
+        * A threshold of tolerance for fuzzy matching on your --count. This is based on Levenshtein Distance; If you don't set this parameter, it will default to perfect matches. 
+    * Remove Numbers **(--remove-numbers _boolean_)**
+        * Remove numbers from the alert alias before performing fuzzy matching in --count. This defaults to False and should be used in conjunction with the fuzzy threshold flag.
+
 
 **Note:** `limit`, `interval`, `match` and `outfile` can all be chained to filter results of `count`. If `outfile` is specified `limit` is ignored.
 
@@ -30,6 +35,7 @@ This requires Python3
 pip install virtualenv
 virtualenv -p python3 venv
 source venv/bin/activate
+pip install -r requirements.txt
 ```
 
 
@@ -52,6 +58,16 @@ python main.py alert-data-raw.csv --count
 - Get a count of alerts grouped by the column "Alias"
 ```
 python main.py alert-data-raw.csv --count Alias
+```
+
+- Get a count of alerts grouped by the column "Alias" and with a fuzzy matching threshold of 90%
+```
+python main.py alert-data-raw.csv --count Alias --fuzzy-threshold 90
+```
+
+- Get a count of alerts grouped by the column "Alias" and with a fuzzy matching threshold of 90% and numbers removed from the alias before the fuzzy matching
+```
+python main.py alert-data-raw.csv --count Alias --fuzzy-threshold 90 --remove-numbers True
 ```
 
 - Get a count of all alerts grouped by the column "Alias" that are created between the hours of 04 and 13 (UTC)

--- a/README.md
+++ b/README.md
@@ -22,6 +22,8 @@ Helpful functions for analyzing an export of OpsGenie alerts and collecting usef
         * A threshold of tolerance for fuzzy matching on your --count. This is based on Levenshtein Distance; If you don't set this parameter, it will default to perfect matches. 
     * Remove Numbers **(--remove-numbers _boolean_)**
         * Remove numbers from the alert alias before performing fuzzy matching in --count. This defaults to False and should be used in conjunction with the fuzzy threshold flag.
+    * Alias Strip List File **(--alias-strip-list _csv_)**
+        * Remove strings from the alert alias before performing matching in --count. Input for this flag is a csv without headers that contains a single column of strings to strip out of the alias (e.g. server names).
 
 
 **Note:** `limit`, `interval`, `match` and `outfile` can all be chained to filter results of `count`. If `outfile` is specified `limit` is ignored.
@@ -58,6 +60,11 @@ python main.py alert-data-raw.csv --count
 - Get a count of alerts grouped by the column "Alias"
 ```
 python main.py alert-data-raw.csv --count Alias
+```
+
+- Get a count of alerts grouped by the column "Alias" with server names stripped out
+```
+python main.py alert-data-raw.csv --count Alias --alias-strip-list server_names.csv
 ```
 
 - Get a count of alerts grouped by the column "Alias" and with a fuzzy matching threshold of 90%

--- a/count.py
+++ b/count.py
@@ -7,12 +7,12 @@ from fuzzywuzzy import fuzz
 class Counter(object):
 
     def count(self, file, column, limit, interval, match, fuzzy_thresh, remove_numbers, update_minutes, outfile, alias_strip_list):
+        strip_list = []
         if alias_strip_list:
             with open(alias_strip_list, 'rt', encoding='utf-8') as f:
                 csv_reader = csv.reader(f)
                 values_to_strip = list(csv_reader)
                 strip_list = [item[0] for item in values_to_strip] 
-                print(strip_list)
 
         with open(file, 'r') as f:
             reader = csv.reader(f, delimiter=',')
@@ -32,6 +32,10 @@ class Counter(object):
             count_map = {}
 
             for row in reader:
+                for strip in strip_list:
+                    if strip in row[1]: 
+                        row[1] = row[1].replace(strip, "")
+                        break
                 if match:
                     if match not in row[index]:
                         continue

--- a/count.py
+++ b/count.py
@@ -55,7 +55,7 @@ class Counter(object):
 
                 current_count = count_map.get(row[index], 0)
                 if current_count != 0:
-                    current_count = current_count.get('count')
+                    current_count = current_count.get("count")
                 count_map[row[index]] = {"count": (current_count + 1), "fuzzy": False}
 
         # if the fuzzy threshold is set to 100% match, we can skip this
@@ -66,6 +66,7 @@ class Counter(object):
             count_map = self.count_fuzzy_matches(count_map, fuzzy_thresh, remove_numbers)
 
         alert_list = sorted(count_map.items(), 
+                            key = lambda kv:(kv[1].get("count"), kv[0]), 
                             reverse=True)
 
         if not outfile:
@@ -77,9 +78,15 @@ class Counter(object):
         else:
             with open(outfile, 'w') as out:
                 writer = csv.writer(out, delimiter=',')
-                writer.writerow([column, "Count", "Includes Fuzzy Matches"])
+                if fuzzy_thresh < 100:
+                    writer.writerow([column, "Count", "Includes Fuzzy Matches"])
+                else:
+                    writer.writerow([column, "Count"])
                 for row in alert_list:
-                    row_to_write = (row[0], row[1].get("count"), row[1].get("fuzzy"))
+                    if fuzzy_thresh < 100:
+                        row_to_write = (row[0], row[1].get("count"), row[1].get("fuzzy"))
+                    else:
+                        row_to_write = (row[0], row[1].get("count"))
                     writer.writerow(row_to_write)
             print("Done")
 

--- a/count.py
+++ b/count.py
@@ -1,11 +1,12 @@
 import csv
 from datetime import datetime
 from utils import get_valid_colum_indices
+from fuzzywuzzy import fuzz
 
 
-class Counter:
+class Counter(object):
 
-    def count(file, column, limit, interval, match, update_minutes, outfile):
+    def count(self, file, column, limit, interval, match, fuzzy_thresh, remove_numbers, update_minutes, outfile):
         with open(file, 'r') as f:
             reader = csv.reader(f, delimiter=',')
             headers = next(reader)
@@ -40,10 +41,20 @@ class Counter:
                     dtime = datetime.strptime(row[indices[1]][0:-9], '%Y/%m/%d %H:%M:%S')
                     if dtime.hour < int(interval[0]) or dtime.hour > int(interval[1]):
                         continue
-                count_map[row[index]] = count_map.get(row[index], 0) + 1
 
-        alert_list = sorted(count_map.items(),
-                            key = lambda kv:(kv[1], kv[0]), 
+                current_count = count_map.get(row[index], 0)
+                if current_count != 0:
+                    current_count = current_count.get('count')
+                count_map[row[index]] = {"count": (current_count + 1), "fuzzy": False}
+
+        # if the fuzzy threshold is set to 100% match, we can skip this
+        # O Notation murdering step
+        if fuzzy_thresh < 100:
+            # Get a list of the keys in the count_map
+            # Then see if any are a fuzzy match
+            count_map = self.count_fuzzy_matches(count_map, fuzzy_thresh, remove_numbers)
+
+        alert_list = sorted(count_map.items(), 
                             reverse=True)
 
         if not outfile:
@@ -55,7 +66,32 @@ class Counter:
         else:
             with open(outfile, 'w') as out:
                 writer = csv.writer(out, delimiter=',')
-                writer.writerow([column, "Count"])
+                writer.writerow([column, "Count", "Includes Fuzzy Matches"])
                 for row in alert_list:
-                    writer.writerow(row)
+                    row_to_write = (row[0], row[1].get("count"), row[1].get("fuzzy"))
+                    writer.writerow(row_to_write)
             print("Done")
+
+    @classmethod
+    def count_fuzzy_matches(self, count_map, fuzzy_thresh, remove_numbers):
+        alert_keys = list(count_map.keys())
+        skip_list = []
+        for key, val in count_map.items():
+            if key not in skip_list:
+                for alert_key in alert_keys:
+                    if remove_numbers:
+                        new_key = ''.join([i for i in key if not i.isdigit()])
+                        new_alert_key = ''.join([i for i in alert_key if not i.isdigit()])
+                    else:
+                        new_key = key
+                        new_alert_key = alert_key
+                    fuzzy_match_ratio = fuzz.ratio(new_key, new_alert_key) 
+                    if fuzzy_match_ratio >= fuzzy_thresh:
+                        if key != alert_key:
+                            count_map[key] = {"count": (count_map[key]['count'] + count_map[alert_key]['count']), "fuzzy": True}
+                            skip_list.append(alert_key)
+        for skip in skip_list:
+            if count_map.get(skip):
+                del count_map[skip]
+
+        return count_map

--- a/count.py
+++ b/count.py
@@ -6,7 +6,14 @@ from fuzzywuzzy import fuzz
 
 class Counter(object):
 
-    def count(self, file, column, limit, interval, match, fuzzy_thresh, remove_numbers, update_minutes, outfile):
+    def count(self, file, column, limit, interval, match, fuzzy_thresh, remove_numbers, update_minutes, outfile, alias_strip_list):
+        if alias_strip_list:
+            with open(alias_strip_list, 'rt', encoding='utf-8') as f:
+                csv_reader = csv.reader(f)
+                values_to_strip = list(csv_reader)
+                strip_list = [item[0] for item in values_to_strip] 
+                print(strip_list)
+
         with open(file, 'r') as f:
             reader = csv.reader(f, delimiter=',')
             headers = next(reader)

--- a/main.py
+++ b/main.py
@@ -29,6 +29,11 @@ if __name__ == '__main__':
                         help="Number of minutes between 'CreatedAt' and 'UpdatedAt'")
     parser.add_argument("--outfile", nargs='?', dest="outfile", default=None, const=None,
                         help="Optional file to output results of count")
+    parser.add_argument("--fuzzy-threshold", nargs='?', dest="fuzzy_thresh", default=100, const=None, type=int,
+                        help="Threshold for alert fuzzy match (default: 100 - so 100% match)")
+    parser.add_argument("--remove-numbers", nargs='?', dest="remove_numbers", default=False, const=None, type=bool,
+                        help="Remove numbers from alias before doing fuzzy matching (default: False). \
+                        To be used in conjuction with the fuzzy threshold flag")
     args = parser.parse_args()
 
     if args.clean:
@@ -36,5 +41,7 @@ if __name__ == '__main__':
             parser.error("The file {} does not end with 'raw.csv'".format(args.file))
         Cleaner.clean(args.file, args.clean, args.remove)
     elif args.count:
-        Counter.count(args.file, args.count, args.limit, args.interval,
-                      args.match, args.update_minutes, args.outfile)
+        counter = Counter()
+        counter.count(file=args.file, column=args.count, limit=args.limit, interval=args.interval,
+                      match=args.match, fuzzy_thresh=args.fuzzy_thresh, remove_numbers=args.remove_numbers, 
+                      update_minutes=args.update_minutes, outfile=args.outfile)

--- a/main.py
+++ b/main.py
@@ -34,6 +34,8 @@ if __name__ == '__main__':
     parser.add_argument("--remove-numbers", nargs='?', dest="remove_numbers", default=False, const=None, type=bool,
                         help="Remove numbers from alias before doing fuzzy matching (default: False). \
                         To be used in conjuction with the fuzzy threshold flag")
+    parser.add_argument('--alias-strip-list', type=lambda x: is_valid_file(parser, x),
+                        dest='strip_file', help='csv file with a column of values to strip', metavar="FILE")
     args = parser.parse_args()
 
     if args.clean:
@@ -44,4 +46,4 @@ if __name__ == '__main__':
         counter = Counter()
         counter.count(file=args.file, column=args.count, limit=args.limit, interval=args.interval,
                       match=args.match, fuzzy_thresh=args.fuzzy_thresh, remove_numbers=args.remove_numbers, 
-                      update_minutes=args.update_minutes, outfile=args.outfile)
+                      update_minutes=args.update_minutes, outfile=args.outfile, alias_strip_list=args.strip_file)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+fuzzywuzzy==0.17.0
+python-Levenshtein==0.12.0


### PR DESCRIPTION
# Fuzzy Matching
This adds the option to do fuzzy matching on the alias counts. Not perfect because it just retains the alias of the first one it matches on, but a decent start, I think!

The script arg defaults to 100% match but you can pass a --fuzzy-threshold argument with lower numbers if you want to include fuzzy matching.

Good news! this is actually fast - it seemed slow because I was printing the output, but if you don't have any logging it will process thousands of alerts within seconds.

# Remove Numbers
I also added a --remove-numbers flag to be used with fuzzy matching. It strips the numbers out of the two aliases before comparing them. Added this because the shorter the string the lower you have to set the Levenshtein distance to get a match (even if the alerts are literally one number apart). This might be helpful just for bitly alerts but...

# Alias Strip List
Two things to admit about this:
1) I meant to do this on another branch but then I accidentally did it on this branch and then left it
2) Not my strongest naming game - lots of "stripping" even though incidentally I don't use strip() at all - please tell me if you can think of a better one

Basically what this does is allow you to pass a header-less one-column csv with a list of strings you want to strip before doing the matching (I wanted it to ditch server names - could also be used for data centers, etc). This also probably doesn't do great things for the O Notation, but...use at your own risk.

# Requirements
Also I added some dependancies so I included a requirements.txt